### PR TITLE
Add intersections

### DIFF
--- a/src/lib/Path.js
+++ b/src/lib/Path.js
@@ -1,0 +1,12 @@
+export class Path {
+
+  // Assumes data is sorted by time!
+  constructor(data) {
+    this._data = data;
+  }
+
+  get data() {
+    return this._data;
+  }
+
+}

--- a/src/lib/PathHelpers.js
+++ b/src/lib/PathHelpers.js
@@ -1,0 +1,17 @@
+
+// return true if a = b ± padding
+export function fuzzyEqual(a, b, padding) {
+  return Math.abs(a-b) <= Math.abs(padding);
+}
+
+// return distance in km between lat/long points
+// credit to https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
+export function distance(lat1, lon1, lat2, lon2) {
+  var p = 0.017453292519943295; // Math.PI / 180
+  var c = Math.cos;
+  var a = 0.5 - c((lat2 - lat1) * p)/2 + 
+          c(lat1 * p) * c(lat2 * p) * 
+          (1 - c((lon2 - lon1) * p))/2;
+
+  return 12742 * Math.asin(Math.sqrt(a)); // 2 * R; R = 6371 km
+}

--- a/src/lib/Paths.js
+++ b/src/lib/Paths.js
@@ -1,0 +1,63 @@
+import { distance, fuzzyEqual } from "./PathHelpers"
+
+export const DEFAULT_TIME_IMPRECISON = 0; // integer seconds
+export const DEFAULT_LOCATION_IMPRECISON = 0; // decimal degrees: 1.0° ~ 111km, 0.01° ~ 1.11km, 0.00001° ~ 1.11m
+
+export class Paths {
+
+  //
+  // Given two Path objects, path, and otherPath, calculate intersections with the following options:
+  //   - timePadding - for determining a time match, time1 == time2 ± timeImprecision
+  //   - locationPadding - for determining a location match, location1 == location1 ± locationImprecision
+  //
+  // Returns matches of time/location in the format of:
+  //   { 
+  //     intersections: [
+  //       { 
+  //         time: 1585609900112, // time of intersection (this is always the time in Path, not otherPath)
+  //         distance: 0.0031, // distance in km
+  //       }
+  //     ]
+  //   }
+  //
+  // TODO: consider returning only one (closest) intersection per time along `path`, in the even there are 
+  //       multiple intersections at the same time.
+  static intersections(path, otherPath, options = {}) {
+    let timePadding = options.timePadding || DEFAULT_TIME_IMPRECISON;
+    let locationPadding = options.locationPadding || DEFAULT_LOCATION_IMPRECISON;
+    let intersections = [];
+
+    let pi = 0;
+    let oi = 0;
+    let search = true;
+
+    while(search) {
+      
+      let p = path.data[pi];
+      let o = otherPath.data[oi];
+      let intersection = false;
+
+      // check time and location intersection
+      if (fuzzyEqual(o.time, p.time, timePadding) &&
+          fuzzyEqual(o.lat,  p.lat,  locationPadding) &&
+          fuzzyEqual(o.long, p.long, locationPadding)) {
+            intersections.push({ 
+              time: p.time,
+              distance: distance(p.lat, p.long, o.lat, o.long),
+            })
+            intersection = true
+          }
+
+      // advance o when o.time < p.time - padding OR when there is an intersection
+      // advance p when p.time + padding < o.time
+      // stop when either p[pi] or o[oi] would go out of bounds
+      if(p.time + timePadding < o.time && !intersection) {
+        (pi >= path.data.length - 1) ? search = false : pi++;
+      } else {
+        (oi >= otherPath.data.length - 1) ? search = false : oi++;
+      }
+    }
+
+    return { intersections };
+  }
+}

--- a/src/lib/__tests__/Path-test.js
+++ b/src/lib/__tests__/Path-test.js
@@ -1,0 +1,18 @@
+import { Path } from "../Path";
+
+describe("Path", () => {
+  const pathData = [
+    { time: 1585609195112, lat: 44.9680, long:  -89.1320 },
+    { time: 1585609195212, lat: 33.7557, long: -116.3599 },
+  ];
+
+  const subject = () => new Path(pathData);
+
+  describe("when instantiated", () => {
+    it(`returns data`, () => {
+      expect(subject().data).toEqual(pathData);
+    });
+  });
+
+});
+

--- a/src/lib/__tests__/PathHelpers-test.js
+++ b/src/lib/__tests__/PathHelpers-test.js
@@ -1,0 +1,36 @@
+import { fuzzyEqual, distance } from "../PathHelpers";
+
+describe("fuzzyEqual", () => {
+  it(`returns true when equal`, () => {
+    expect(fuzzyEqual(5, 5, 0)).toBe(true);
+  });
+
+  it(`returns false outside of padding`, () => {
+    expect(fuzzyEqual(5, 7, 1)).toBe(false);
+  });
+
+  it(`returns true with negative value`, () => {
+    expect(fuzzyEqual(-1, 1, 2)).toBe(true);
+  });
+
+  it(`returns true with negative padding`, () => {
+    expect(fuzzyEqual(-1, 1, -2)).toBe(true);
+  });
+});
+
+describe("distance", () => {
+  let seattle = { lat: 47.609755, long: -122.337793 }
+  let helsinki = { lat: 60.169840, long: 24.938330 }
+
+  it(`returns 0 for same location`, () => {
+    expect(distance(seattle.lat, seattle.long, seattle.lat, seattle.long)).toEqual(0);
+  });
+  
+  it(`returns for close distances`, () => {
+    expect(distance(seattle.lat + 0.00001, seattle.long - 0.00001, seattle.lat, seattle.long)).toEqual(0.0013401301088928606);
+  });
+  
+  it(`returns for distant locations`, () => {
+    expect(distance(seattle.lat, seattle.long, helsinki.lat, helsinki.long)).toEqual(7670.988740099061);
+  });
+});

--- a/src/lib/__tests__/Paths-test.js
+++ b/src/lib/__tests__/Paths-test.js
@@ -1,0 +1,66 @@
+import { Paths } from "../Paths";
+import { Path } from "../Path"
+import { distance } from "../PathHelpers"
+
+describe("Paths", () => {
+  let path1;
+  let path2;
+
+  describe("intersections", () => {
+    
+    it(`returns no intersections when no time overlap`, () => {
+      path1 = new Path([
+        { time: 800, lat: 44.0000, long:  -93.0000 },
+        { time: 700, lat: 44.0000, long:  -91.0000 },
+      ]);
+      path2 = new Path([
+        { time: 200, lat: 44.0000, long:  -93.0000 },
+        { time: 900, lat: 44.0000, long:  -91.0000 },
+      ]);
+      expect(Paths.intersections(path1, path2)).toEqual({intersections: []});
+    });
+
+    it(`returns intersections for exact location/time matches`, () => {
+      path1 = new Path([
+        { time: 200, lat: 44.0000, long:  -93.0000 },
+        { time: 300, lat: 44.0000, long:  -97.0000 },
+        { time: 400, lat: 44.0000, long:  -93.0000 },
+        { time: 500, lat: 44.0000, long:  -97.0000 },
+      ]);
+      path2 = new Path([
+        { time: 300, lat: 44.0000, long:  -97.0000 },
+        { time: 400, lat: 44.0000, long:  -93.0000 },
+      ]);
+      expect(Paths.intersections(path1, path2)).toEqual({intersections: [
+        { time: 300, distance: 0 },
+        { time: 400, distance: 0 },
+      ]});
+    });
+
+    it(`returns intersections for fuzzy time and locaztion matches`, () => {
+      path1 = new Path([
+        { time: 10, lat: 44.0000, long:  -97.0000 },
+        { time: 25, lat: 44.0000, long:  -97.0000 },
+        { time: 29, lat: 44.0000, long:  -97.0000 }, // wrong time
+      ]);
+      path2 = new Path([
+        { time: 4,  lat: 44.0000, long: -97.0000 },  // wrong time
+        { time: 5,  lat: 44.0000, long: -97.0000 },
+        { time: 6,  lat: 41.0000, long: -100.0000 },
+        { time: 7,  lat: 44.0000, long: -93.9999 }, // wrong long
+        { time: 10, lat: 44.0000, long: -97.0000 },
+        { time: 19, lat: 44.0000, long: -97.0000 }, // wrong time
+        { time: 21, lat: 44.0000, long: -97.0000 },
+      ]);
+      expect(Paths.intersections(path1, path2, {timePadding: 5, locationPadding: 3})).toEqual({intersections: [
+        { time: 10, distance: 0 },
+        { time: 10, distance: distance(path1.data[0].lat, path1.data[0].long, path2.data[2].lat, path2.data[2].long) },
+        { time: 10, distance: 0 },
+        { time: 25, distance: 0 },
+      ]});
+    });
+    
+  });
+
+});
+


### PR DESCRIPTION
Initial javascript implementation of path intersections. It takes two time-sorted lists (Path objects) and computes the intersections. Supports padding for time and location. Since the lists are sorted, it just is a matter of maintaining two pointers and walking through both lists. I put in a couple test cases, but it is possible I missed some edge cases. 

Some items we can easily adjust as the rest of the project moves along:
- for input I am using epoch time, need to figure out what the server will be sending
- intersections return time on the first path + distance, however these might need to be batched or throttled in some way for user display, not sure yet about the requirements.