### PR TITLE
Integrate APIs, add debug menu 

### DIFF
--- a/__tests__/App.js
+++ b/__tests__/App.js
@@ -10,7 +10,7 @@ jest.mock('expo', () => ({
   AppLoading: 'AppLoading',
 }));
 
-jest.mock('../navigation/AppNavigator', () => 'AppNavigator');
+jest.mock('../src/navigation/AppNavigator', () => 'AppNavigator');
 
 describe('App', () => {
   jest.useFakeTimers();

--- a/assets/languages/en.json
+++ b/assets/languages/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "header": "Header",
-    "get_started": "Get Started {{date, DD MMM YY}}",
+    "debug_menu": "Debug Menu {{date, DD MMM YY}}",
     "enable_background_location":"Enable background location",
     "user_phone_from_store":"User phone from store:"
   }

--- a/src/lib/Api.js
+++ b/src/lib/Api.js
@@ -1,0 +1,70 @@
+
+// TODO: move this to a config manager, such as react-native-config
+const CONFIG = {
+  API_ENDPOINT: "https://www.myguardian.world/api"
+}
+
+const DEFAULT_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8'
+}
+
+async function sendPath(path) {
+  const body = JSON.stringify({path});
+
+  return new Promise((resolve, reject)=>{
+    fetch(`${CONFIG.API_ENDPOINT}/users/path`, {
+      method: 'POST',
+      headers: DEFAULT_HEADERS,
+      body,
+    })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch((error) => reject(error));
+  });
+};
+
+async function signUp(phoneNumber) {
+  const body = JSON.stringify({
+    "phone_number": phoneNumber,
+  });
+
+  return new Promise((resolve, reject)=>{
+    fetch(`${CONFIG.API_ENDPOINT}/users/sign_up`, {
+      method: 'POST',
+      headers: DEFAULT_HEADERS,
+      body,
+    })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch((error) => reject(error));
+  });
+};
+
+async function signIn({registrationId, registrationCode}) {
+  const body = JSON.stringify({
+    id: registrationId,
+    code: registrationCode,
+  });
+
+  return new Promise((resolve, reject)=>{
+    fetch(`${CONFIG.API_ENDPOINT}/users/sign_in`, {
+      method: 'POST',
+      headers: DEFAULT_HEADERS,
+      body,
+    })
+    .then((response) => response.json())
+    .then((data) => {
+      return resolve({
+        sessionId: data.data.user.id,
+        sessionPhone: data.data.user["phone_number"],
+      })
+    })
+    .catch((error) => reject(error));
+  });
+};
+
+export {
+  sendPath,
+  signUp,
+  signIn,
+};

--- a/src/lib/Api.js
+++ b/src/lib/Api.js
@@ -9,13 +9,25 @@ const DEFAULT_HEADERS = {
 }
 
 async function sendPath(path) {
-  const body = JSON.stringify({path});
+  const body = JSON.stringify({points: path});
 
   return new Promise((resolve, reject)=>{
     fetch(`${CONFIG.API_ENDPOINT}/users/path`, {
       method: 'POST',
       headers: DEFAULT_HEADERS,
       body,
+    })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch((error) => reject(error));
+  });
+};
+
+async function getPath() {
+  return new Promise((resolve, reject)=>{
+    fetch(`${CONFIG.API_ENDPOINT}/users/path`, {
+      method: 'GET',
+      headers: DEFAULT_HEADERS,
     })
     .then((response) => response.json())
     .then((data) => resolve(data))
@@ -55,8 +67,7 @@ async function signIn({registrationId, registrationCode}) {
     .then((response) => response.json())
     .then((data) => {
       return resolve({
-        sessionId: data.data.user.id,
-        sessionPhone: data.data.user["phone_number"],
+        sessionId: data["user_id"],
       })
     })
     .catch((error) => reject(error));
@@ -64,6 +75,7 @@ async function signIn({registrationId, registrationCode}) {
 };
 
 export {
+  getPath,
   sendPath,
   signUp,
   signIn,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -15,6 +15,7 @@ import {
   resetStore 
 } from "Store/actions";
 import {
+  getPath,
   sendPath,
   signIn,
   signUp, 
@@ -80,10 +81,9 @@ const HomeScreen = () => {
       registrationId: state.registrationId, 
       registrationCode: state.registrationCode,
     }).then((data) =>{
-      const { sessionId, sessionPhone } = data;
-
+      const { sessionId } = data;
       // store session information for subsequent requests
-      dispatch(setUserSession({ sessionId, sessionPhone }))
+      dispatch(setUserSession({ sessionId }))
     })
   }
 
@@ -105,6 +105,12 @@ const HomeScreen = () => {
       if(data.errors.length === 0) {
         dispatch(setUserLastPathSentTime({ time: Date.now() }));
       }
+    })
+  }
+
+  const onGetPath = () => {
+    getPath().then((data) =>{
+      console.log("got path data", data)
     })
   }
 
@@ -144,6 +150,8 @@ const HomeScreen = () => {
       {actionRow("1. signUp", "POST /sign_up API", onSignUp)}
       {actionRow("2. signIn", "POST /sign_in API", onSignIn)}
       {actionRow("3. path", "POST /path API", onSendPath)}
+      {actionRow("[DEBUG] get path", "GET /path API", onGetPath)}
+
       {actionRow("resetStore", "resets the store to initial values", () => dispatch(resetStore()))}
 
       <Text>Store</Text>

--- a/src/store/__tests__/reducer-test.js
+++ b/src/store/__tests__/reducer-test.js
@@ -1,10 +1,18 @@
 import { rootReducer as reducer, initialState } from "../reducer";
 
 import {
+  setUserLastPathSentTime,
+  setUserSignUpData,
   setUserPhone,
+  setUserSession,
+  resetStore,
 } from "../actions"
 
 const fakePhone = "999-000-1234";
+const registrationCode = "a498l"
+const registrationId = "p07"
+const sessionId = "lhkwfoeih"
+const sessionPhone = fakePhone
 
 describe("rootReducer", () => {
   it(`handles supported action`, () => {
@@ -12,8 +20,37 @@ describe("rootReducer", () => {
     expect(state).toEqual(initialState);
   });
 
+  it(`handles setUserSignUpData`, () => {
+    const state = reducer(undefined, setUserSignUpData({
+      registrationCode, 
+      registrationId,
+    }));
+    expect(state.registrationCode).toEqual(registrationCode);
+    expect(state.registrationId).toEqual(registrationId);
+  });
+
+  it(`handles setUserSession`, () => {
+    const state = reducer(undefined, setUserSession({
+      sessionId, 
+      sessionPhone,
+    }));
+    expect(state.sessionId).toEqual(sessionId);
+    expect(state.sessionPhone).toEqual(sessionPhone);
+  });
+
+  it(`handles setUserLastPathSentTime`, () => {
+    let date = new Date();
+    const state = reducer(undefined, setUserLastPathSentTime({ time: date }));
+    expect(state.lastPathSentTime).toEqual(date);
+  });
+
   it(`handles setUserPhone`, () => {
     const state = reducer(undefined, setUserPhone(fakePhone));
     expect(state.userPhone).toEqual(fakePhone);
+  });
+
+  it(`handles resetStore`, () => {
+    const state = reducer({something: false}, resetStore());
+    expect(state).toEqual(initialState);
   });
 });

--- a/src/store/__tests__/reducer-test.js
+++ b/src/store/__tests__/reducer-test.js
@@ -12,7 +12,6 @@ const fakePhone = "999-000-1234";
 const registrationCode = "a498l"
 const registrationId = "p07"
 const sessionId = "lhkwfoeih"
-const sessionPhone = fakePhone
 
 describe("rootReducer", () => {
   it(`handles supported action`, () => {
@@ -32,10 +31,8 @@ describe("rootReducer", () => {
   it(`handles setUserSession`, () => {
     const state = reducer(undefined, setUserSession({
       sessionId, 
-      sessionPhone,
     }));
     expect(state.sessionId).toEqual(sessionId);
-    expect(state.sessionPhone).toEqual(sessionPhone);
   });
 
   it(`handles setUserLastPathSentTime`, () => {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -18,7 +18,6 @@ export function setUserSession({ sessionId, sessionPhone }) {
     type: SET_USER_SESSION,
     payload: {
       sessionId,
-      sessionPhone,
     },
   };
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,4 +1,8 @@
-export const SET_USER_PHONE = "SET_USER_PHONE"
+export const SET_USER_PHONE = "SET_USER_PHONE";
+export const SET_USER_SESSION = "SET_USER_SESSION";
+export const SET_USER_SIGNUP_DATA = "SET_USER_SIGNUP_DATA";
+export const SET_USER_LAST_PATH_SENT_TIME = "SET_USER_LAST_PATH_SENT_TIME";
+export const RESET_STORE = "RESET_STORE";
 
 export function setUserPhone(userPhone) {
   return {
@@ -6,5 +10,40 @@ export function setUserPhone(userPhone) {
     payload: {
       userPhone,
     },
+  };
+}
+
+export function setUserSession({ sessionId, sessionPhone }) {
+  return {
+    type: SET_USER_SESSION,
+    payload: {
+      sessionId,
+      sessionPhone,
+    },
+  };
+}
+
+export function setUserSignUpData({ registrationCode, registrationId }) {
+  return {
+    type: SET_USER_SIGNUP_DATA,
+    payload: {
+      registrationCode,
+      registrationId,
+    },
+  };
+}
+
+export function setUserLastPathSentTime({ time }) {
+  return {
+    type: SET_USER_LAST_PATH_SENT_TIME,
+    payload: {
+      time,
+    },
+  };
+}
+
+export function resetStore() {
+  return {
+    type: RESET_STORE,
   };
 }

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,10 +1,19 @@
 
 import {
+  SET_USER_LAST_PATH_SENT_TIME,
   SET_USER_PHONE,
+  SET_USER_SESSION,
+  SET_USER_SIGNUP_DATA,
+  RESET_STORE,
 } from "./actions"
 
 export const initialState = {
   userPhone: "",
+  registrationCode: null,
+  registrationId: null,
+  sessionId: null,
+  sessionPhone: null,
+  lastPathSentTime: null
 }
 
 export const rootReducer = (state = initialState, action) => {
@@ -14,6 +23,25 @@ export const rootReducer = (state = initialState, action) => {
         ...state,
         userPhone: (action.payload && action.payload.userPhone) || "",
       };
+    case SET_USER_SIGNUP_DATA:
+      return {
+        ...state,
+        registrationCode: (action.payload && action.payload.registrationCode) || null,
+        registrationId: (action.payload && action.payload.registrationId) || null,
+      };
+    case SET_USER_SESSION:
+      return {
+        ...state,
+        sessionId: (action.payload && action.payload.sessionId) || null,
+        sessionPhone: (action.payload && action.payload.sessionPhone) || null,
+      };
+    case SET_USER_LAST_PATH_SENT_TIME:
+      return {
+        ...state,
+        lastPathSentTime: (action.payload && action.payload.time) || null,
+      };
+    case RESET_STORE:
+      return initialState;
     default: {
       return state;
     }

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -12,7 +12,6 @@ export const initialState = {
   registrationCode: null,
   registrationId: null,
   sessionId: null,
-  sessionPhone: null,
   lastPathSentTime: null
 }
 
@@ -33,7 +32,6 @@ export const rootReducer = (state = initialState, action) => {
       return {
         ...state,
         sessionId: (action.payload && action.payload.sessionId) || null,
-        sessionPhone: (action.payload && action.payload.sessionPhone) || null,
       };
     case SET_USER_LAST_PATH_SENT_TIME:
       return {


### PR DESCRIPTION
This adds a debug menu. It shows three things
1. Some editable "low-fi" inputs, which are provided by the user or the device (such as location, or the JSON path that will be stored locally on the phone.
2. A list of clickable actions, the first 3 invoke the server APIs using inputs from the inputs, and the last one resets the store to it's initial state. Together these let a developer or tester quickly validate the end to end API flow without the UI (which is still being developed).
3. A dump of the redux store, which lets you see how state changes as various actions occur. This may also be useful for people debugging on a device, without Redux DevTools.

Here is a fun gif to show it in action

![debug_menu](https://user-images.githubusercontent.com/168993/78463352-8b244680-7690-11ea-945d-8f853cc86a0d.gif)
