### PR TITLE
refactor storage.js for reuse, add session to device storage

### DIFF
--- a/src/components/HomeScreen.js
+++ b/src/components/HomeScreen.js
@@ -8,18 +8,18 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 
 import { t } from 'Lib/i18n';
-import { routeTo } from "Store/actions";
+import { 
+  sessionNotFound, 
+  routeTo,
+} from "Store/actions";
 import { Pages } from "Lib/Pages";
 
-
 const HomeScreen = () => {
-
-  // Route to signin if there is no session.
-  const { sessionId } = useSelector(state => state);
+  const { accessToken } = useSelector(state => state);
   const dispatch = useDispatch();
 
-  if (!sessionId) {
-    dispatch(routeTo(Pages.SIGNUP));
+  if (!accessToken) {
+    dispatch(sessionNotFound());
     return <></>;
   }
 

--- a/src/components/LocationScreen.js
+++ b/src/components/LocationScreen.js
@@ -7,7 +7,7 @@ import {
   AsyncStorage
 } from "react-native";
 import Constants from "expo-constants";
-import * as Location from "expo-location";
+import * as ExpoLocation from "expo-location";
 import * as TaskManager from "expo-task-manager";
 import React, { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
@@ -15,11 +15,8 @@ import { LinearGradient } from "expo-linear-gradient";
 import { t } from 'Lib/i18n';
 import { routeTo } from "Store/actions";
 import { Pages } from "Lib/Pages";
+import Location from "Lib/models/Location";
 
-import {
-  getMostRecentLocations,
-  addLocationToDatabase,
-} from "Lib/Storage";
 import moment from 'moment';
 import BackgroundGeolocation, {
   MotionChangeEvent,
@@ -127,8 +124,8 @@ const LocationScreen = () => {
   onLocation = async (location) => {
     console.log('[location] -', location);
     setLocation(location);
-    var locationObject = [JSON.stringify(location.coords.latitude), JSON.stringify(location.coords.longitude), location.timestamp];
-    await addLocationToDatabase(locationObject);
+    await Location.insert([location.coords.latitude, location.coords.longitude, location.timestamp]);
+    return
   }
 
   onError  = async (error) => {
@@ -142,8 +139,7 @@ const LocationScreen = () => {
   }
   onMotionChange  = async (event) => {
     console.log('[motionchange] -', event.isMoving, event.location);
-    var locationObject = [JSON.stringify(event.location.coords.latitude), JSON.stringify(event.location.coords.longitude), event.location.timestamp];
-    await addLocationToDatabase(locationObject);
+    await Location.insert([location.coords.latitude, location.coords.longitude, location.timestamp]);
   }
 
   const saveUsername = async(inputText) => {
@@ -154,9 +150,9 @@ const LocationScreen = () => {
   }
 
   const onPress = async () => {
-    var locationsInDb = await getMostRecentLocations(100); //get most recent 10 locations
-    console.log("most recent - locations updates", JSON.stringify(locationsInDb));
-    alert(JSON.stringify(locationsInDb));
+    var locationsInDb = (await Location.read({limit: 10})).history; //get most recent 10 locations
+    console.log("most recent - locations updates", locationsInDb);
+    alert(locationsInDb);
   };
 
   const onContinue = () => {

--- a/src/lib/models/Location.js
+++ b/src/lib/models/Location.js
@@ -1,0 +1,47 @@
+import Storage from 'Lib/Storage';
+import moment from 'moment';
+
+export default class Location {
+
+  static get NAMESPACE() { return Storage.modelName("location"); }
+
+  // returns location, an object with keys:
+  //   history: time sorted array of points in the form [lat, long, time]
+  static async read(options = {}) {
+    const limit = options.limit || 0;
+    
+    let result = await Storage.load(Location.NAMESPACE);
+
+    if (limit > 0) {
+      const start = result.history.length - limit;
+      result.history = result.history.slice(start > 0 ? start : 0)
+    }
+
+    return result;
+  }
+
+  // insert a newLocation into the history
+  static async insert(newLocation) {
+    let locationData = await Location.read();
+    locationData = locationData || {};
+    let history = locationData.history ? locationData.history : [];
+    history.push(newLocation);
+
+    // sort history before write
+    history = await sortLocationByTime(history);
+    locationData.history = history;
+
+    return Storage.write(Location.NAMESPACE, locationData);
+  }
+
+  static async destroy() { 
+    return Storage.remove(Location.NAMESPACE);
+  }
+
+}
+
+function sortLocationByTime(locations) {
+  return locations.sort((a, b) => moment(a[2]).format("x") - moment(b[2]).format("x"));
+}
+
+

--- a/src/lib/models/Session.js
+++ b/src/lib/models/Session.js
@@ -1,0 +1,19 @@
+import Storage from 'Lib/Storage';
+
+export default class Session {
+
+  static get NAMESPACE() { return Storage.modelName("session"); }
+
+  static async read() {
+      return Storage.load(Session.NAMESPACE);
+  }
+
+  static async write(session) {
+    return Storage.write(Session.NAMESPACE, session);
+  }
+
+  static async destroy() { 
+    return Storage.remove(Session.NAMESPACE);
+  }
+
+}

--- a/src/sagas/RootSaga.js
+++ b/src/sagas/RootSaga.js
@@ -3,6 +3,7 @@ import {
   watchUserVerify,
   watchFetchMessages,
   watchReportPrecisePath,
+  watchSessionNotFound,
 } from './GuardianSaga'
 import { all } from 'redux-saga/effects'
 
@@ -13,5 +14,6 @@ export function* rootSaga() {
     watchUserVerify(),
     watchFetchMessages(),
     watchReportPrecisePath(),
+    watchSessionNotFound(),
   ]);
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -2,6 +2,7 @@ export const USER_SIGNUP = "USER_SIGNUP";
 export const USER_SIGNUP_VERIFY = "USER_SIGNUP_VERIFY";
 export const REPORT_PRECISE_PATH = "REPORT_PRECISE_PATH";
 export const FETCH_MESSAGES = "FETCH_MESSAGES";
+export const SESSION_NOT_FOUND = "SESSION_NOT_FOUND";
 
 export const ROUTE_TO = "ROUTE_TO";
 export const SAVE_NOTIFICATION = "SAVE_NOTIFICATION";
@@ -43,6 +44,13 @@ export function userSignUpVerify(registrationCode, redirect = true) {
 export function fetchMessages() {
   return {
     type: FETCH_MESSAGES,
+  };
+}
+
+// attempts to load session from storage, otherwise redirect to signup
+export function sessionNotFound() {
+  return {
+    type: SESSION_NOT_FOUND,
   };
 }
 


### PR DESCRIPTION
Changes

1. Refactor Storage.js to be general purpose read/write/encrypt/decrypt data layer utility. The new assumption is that inputs/outputs to reads/writes are plain javascript objects. It is much simpler to let Storage.js handles the serialization. Everything written encrypted by default, but the debugMenu will only decrypt keys with Storage.ENCRPYTION_PREFIX. 

2. The lib/models has been added for business-specific logic and ORM-type stuff. Right now the only models are Location and Session. We will need to add another for Messages in the future. I removed a lot of the code that was specific for locations, as I don't think we will actually need it.

3. I added a number of utilities to the debug menu, including printing out the device storage, deleting all data, and adding a location.

4. The app now writes the session (access and refresh tokens) to persistent device storage on signup, and reads it when a session is not found in the redux store on Pages.HOME.
